### PR TITLE
:zap: support multiple data types for the Sum function

### DIFF
--- a/slices/sum.go
+++ b/slices/sum.go
@@ -1,11 +1,11 @@
 package slices
 
 // Returns the sum of all elements in the slice
-func Sum(numbers []int) int {
-	sum := 0
-	for _, number := range numbers {
-		// Add the number to the sum
-		sum += number
+func Sum[T int | int32 | int64 | float32 | float64 | string](values []T) T {
+	var sum T
+	for _, value := range values {
+		// Add the value to the sum
+		sum += value
 	}
 
 	// Return the sum

--- a/slices/sum_test.go
+++ b/slices/sum_test.go
@@ -3,21 +3,92 @@ package slices
 import "testing"
 
 func TestSum(t *testing.T) {
-	t.Run("Should return the sum of all numbers in a slice", func(t *testing.T) {
-		numbers := []int{4, 6, 32, 5, 3, 8, 10, 1, 2, 9}
-		got := Sum(numbers)
-		want := 80
-		if got != want {
-			t.Errorf("got %d, want %d", got, want)
-		}
-	})
 
-	t.Run("Should return 0 if an empty slice is provided", func(t *testing.T) {
-		numbers := []int{}
-		got := Sum(numbers)
-		want := 0
-		if got != want {
-			t.Errorf("got %d, want %d", got, want)
-		}
-	})
+	type testCase[T int | int32 | int64 | float32 | float64 | string] struct {
+		name     string
+		values   []T
+		expected T
+	}
+
+	testCasesForInt := []testCase[int]{
+		{
+			name:     "Collection of 5 values",
+			values:   []int{1, 2, 3, 4, 5},
+			expected: 15,
+		},
+		{
+			name:     "Collection with one value",
+			values:   []int{1},
+			expected: 1,
+		},
+		{
+			name:     "Empty collection",
+			values:   []int{},
+			expected: 0,
+		},
+	}
+
+	for _, tc := range testCasesForInt {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Sum(tc.values)
+			if got != tc.expected {
+				t.Errorf("got %d, want %d", got, tc.expected)
+			}
+		})
+	}
+
+	testCasesForFloat := []testCase[float64]{
+		{
+			name:     "Collection of 5 values",
+			values:   []float64{1.2, 2.3, 3.4, 4.5, 5.6},
+			expected: 17.0,
+		},
+		{
+			name:     "Collection with one value",
+			values:   []float64{1.2},
+			expected: 1.2,
+		},
+		{
+			name:     "Empty collection",
+			values:   []float64{},
+			expected: 0,
+		},
+	}
+
+	for _, tc := range testCasesForFloat {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Sum(tc.values)
+			if got != tc.expected {
+				t.Errorf("got %f, want %f", got, tc.expected)
+			}
+		})
+	}
+
+	testCasesForString := []testCase[string]{
+		{
+			name:     "Collection of 5 strings",
+			values:   []string{"the ", "quick ", "brown ", "fox ", "jumps"},
+			expected: "the quick brown fox jumps",
+		},
+		{
+			name:     "Collection with one string",
+			values:   []string{"the"},
+			expected: "the",
+		},
+		{
+			name:     "Empty collection",
+			values:   []string{},
+			expected: "",
+		},
+	}
+
+	for _, tc := range testCasesForString {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Sum(tc.values)
+			if got != tc.expected {
+				t.Errorf("got %s, want %s", got, tc.expected)
+			}
+		})
+	}
+
 }


### PR DESCRIPTION
added support for int, int32, int64, float32, float64, and string types in the Sum function